### PR TITLE
Added assign_public_ip and default user_roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ No modules.
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment of the MongoDB cluster | `string` | n/a | yes |
 | <a name="input_feature_compatibility_version"></a> [feature\_compatibility\_version](#input\_feature\_compatibility\_version) | Feature compatibility version of MongoDB | `string` | `null` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | A set of key/value label pairs to assign to the MongoDB cluster | `map(string)` | `{}` | no |
-| <a name="input_mongod_hosts"></a> [mongod\_hosts](#input\_mongod\_hosts) | List of hosts in MongoDB cluster. | <pre>list(object({<br>    zone_id   = optional(string, "ru-central1-a")<br>    subnet_id = string<br>  }))</pre> | n/a | yes |
+| <a name="input_mongod_hosts"></a> [mongod\_hosts](#input\_mongod\_hosts) | List of hosts in MongoDB cluster. | <pre>list(object({<br>    assign_public_ip = optional(bool, false)<br>    zone_id   = optional(string, "ru-central1-a")<br>    subnet_id = string<br>  }))</pre> | n/a | yes |
 | <a name="input_mongodb_version"></a> [mongodb\_version](#input\_mongodb\_version) | Version of the MongoDB server software | `string` | n/a | yes |
 | <a name="input_network_id"></a> [network\_id](#input\_network\_id) | ID of the network, to which the Redis cluster belongs | `string` | n/a | yes |
 | <a name="input_performance_diagnostics"></a> [performance\_diagnostics](#input\_performance\_diagnostics) | Performance diagnostics to the MongoDB cluster | <pre>object({<br>    enabled = optional(bool)<br>  })</pre> | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -45,8 +45,9 @@ resource "yandex_mdb_mongodb_cluster" "mongodb_cluster" {
   dynamic "host" {
     for_each = var.mongod_hosts
     content {
-      zone_id   = try(host.value.zone_id, var.zone_id)
-      subnet_id = try(host.value.subnet_id, var.subnet_id)
+      assign_public_ip = try(host.value.assign_public_ip, false)
+      zone_id          = try(host.value.zone_id, var.zone_id)
+      subnet_id        = try(host.value.subnet_id, var.subnet_id)
     }
   }
 
@@ -70,6 +71,7 @@ resource "yandex_mdb_mongodb_user" "mongodb_user" {
   password   = var.user_password
   permission {
     database_name = var.database_name
+    roles         = var.user_roles
   }
 
   # Добавляем зависимость от ресурса базы данных

--- a/variables.tf
+++ b/variables.tf
@@ -60,6 +60,12 @@ variable "user_password" {
   type        = string
 }
 
+variable "user_roles" {
+  description = "Roles of the user"
+  type        = list
+  default     = ["readWrite"]
+}
+
 variable "resources_mongod_preset" {
   description = "The ID of the preset for computational resources available to a MongoDB host"
   type        = string
@@ -78,6 +84,7 @@ variable "resources_mongod_disk_type" {
 variable "mongod_hosts" {
   description = "List of hosts in MongoDB cluster."
   type = list(object({
+    assign_public_ip = optional(bool, false)
     zone_id   = optional(string, "ru-central1-a")
     subnet_id = string
   }))


### PR DESCRIPTION
There are cases when public access to the database is required. Additionally, I noticed that the default role is not assigned to the user, resulting in insufficient permissions when attempting to connect from an external network. This PR addresses such scenarios.