### PR TITLE
Up mongodb_version in example

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   linters:
     name: 'Terraform Linters'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     defaults:
       run:
         shell: bash
@@ -69,7 +69,7 @@ jobs:
           download_external_modules: false
   semver:
     name: 'Set code version tag'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     needs:

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+.idea

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,12 @@
-```shell
-export YC_FOLDER_ID='xxx'
+## Usage
+
+To run this example you need to execute:
+
+```bash
+export YC_FOLDER_ID='folder_id'
 terraform init
 terraform plan
 terraform apply
 ```
+
+Note that this example may create resources which can cost money. Run `terraform destroy` when you don't need these resources.

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -26,7 +26,7 @@ module "mongodb_cluster" {
 
   cluster_name               = "test-cluster"
   environment                = "PRESTABLE"
-  mongodb_version            = "5.0"
+  mongodb_version            = "6.0"
   labels                     = { test_key = "test_value" }
   database_name              = "testdb"
   user_name                  = "john"
@@ -35,7 +35,7 @@ module "mongodb_cluster" {
   resources_mongod_disk_size = 16
   resources_mongod_disk_type = "network-hdd"
 
-  feature_compatibility_version = "5.0"
+  feature_compatibility_version = "6.0"
 
   mongod_hosts = [
     {

--- a/variables.tf
+++ b/variables.tf
@@ -29,8 +29,12 @@ variable "environment" {
 }
 
 variable "mongodb_version" {
-  description = "Version of the MongoDB server software"
+  description = "Version of the MongoDB server"
   type        = string
+  validation {
+    condition     = contains(["6.0", "7.0", "8.0"], var.mongodb_version)
+    error_message = "The MongoDB server version must be 6.0, 7.0, 8.0"
+  }
 }
 
 variable "feature_compatibility_version" {


### PR DESCRIPTION
Fix
```
│ Error: error while requesting API to create Mongodb Cluster: client-request-id = b5e73cb2-6249-47ac-bb10-3a95cf7cdc06 client-trace-id = 48cdb302-390e-4d1b-9ef5-02939f39ec83 rpc error: code = InvalidArgument desc = version "5.0" is deprecated, allowed versions are: 6.0, 7.0, 8.0
```

Fix
```
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
```